### PR TITLE
Initialize backend structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# habitta
+# Habitta
+
+Backend and frontend monorepo for the Habitta project.
+
+The backend is an Express application written in TypeScript using TypeORM.
+Refer to `backend/` for source code.

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,0 +1,3 @@
+import app from './src/app';
+
+// Entry point for ts-node

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "habitta-backend",
+  "version": "1.0.0",
+  "main": "dist/app.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/app.js",
+    "dev": "ts-node src/app.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "typeorm": "^0.3.17",
+    "reflect-metadata": "^0.1.13",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.0",
+    "sqlite3": "^5.1.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.4"
+  }
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,32 @@
+import 'reflect-metadata';
+import express from 'express';
+import cors from 'cors';
+import { createConnection } from 'typeorm';
+import ormconfig from './config/ormconfig';
+import userRoutes from './routes/userRoutes';
+import leadRoutes from './routes/leadRoutes';
+import planRoutes from './routes/planRoutes';
+import cartRoutes from './routes/cartRoutes';
+import orderRoutes from './routes/orderRoutes';
+import adaptationRoutes from './routes/adaptationRoutes';
+import notificationRoutes from './routes/notificationRoutes';
+import walletRoutes from './routes/walletRoutes';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/users', userRoutes);
+app.use('/api/leads', leadRoutes);
+app.use('/api/plans', planRoutes);
+app.use('/api/carts', cartRoutes);
+app.use('/api/orders', orderRoutes);
+app.use('/api/adaptations', adaptationRoutes);
+app.use('/api/notifications', notificationRoutes);
+app.use('/api/wallets', walletRoutes);
+
+createConnection(ormconfig).then(() => {
+  app.listen(3000, () => console.log('Server running on port 3000'));
+});
+
+export default app;

--- a/backend/src/config/ormconfig.ts
+++ b/backend/src/config/ormconfig.ts
@@ -1,0 +1,20 @@
+import { ConnectionOptions } from 'typeorm';
+import { User } from '../entities/User';
+import { Lead } from '../entities/Lead';
+import { ArchitecturalPlan } from '../entities/ArchitecturalPlan';
+import { Cart } from '../entities/Cart';
+import { CartItem } from '../entities/CartItem';
+import { Order } from '../entities/Order';
+import { AdaptationRequest } from '../entities/AdaptationRequest';
+import { Notification } from '../entities/Notification';
+import { Wallet } from '../entities/Wallet';
+
+const config: ConnectionOptions = {
+  type: 'sqlite',
+  database: 'database.sqlite',
+  synchronize: true,
+  logging: false,
+  entities: [User, Lead, ArchitecturalPlan, Cart, CartItem, Order, AdaptationRequest, Notification, Wallet],
+};
+
+export default config;

--- a/backend/src/entities/AdaptationRequest.ts
+++ b/backend/src/entities/AdaptationRequest.ts
@@ -1,0 +1,21 @@
+import { Entity, Column, ManyToOne } from 'typeorm';
+import { BaseEntity } from './BaseEntity';
+import { Order } from './Order';
+import { User } from './User';
+
+export type AdaptationStatus = 'pending' | 'in_progress' | 'completed' | 'approved';
+
+@Entity()
+export class AdaptationRequest extends BaseEntity {
+  @ManyToOne(() => Order)
+  order: Order;
+
+  @ManyToOne(() => User)
+  architect: User;
+
+  @Column({ type: 'enum', enum: ['pending', 'in_progress', 'completed', 'approved'], default: 'pending' })
+  status: AdaptationStatus;
+
+  @Column({ nullable: true })
+  adjustedPlanUrl: string;
+}

--- a/backend/src/entities/ArchitecturalPlan.ts
+++ b/backend/src/entities/ArchitecturalPlan.ts
@@ -1,0 +1,21 @@
+import { Entity, Column, ManyToOne } from 'typeorm';
+import { BaseEntity } from './BaseEntity';
+import { User } from './User';
+
+@Entity()
+export class ArchitecturalPlan extends BaseEntity {
+  @Column()
+  name: string;
+
+  @Column()
+  description: string;
+
+  @Column('decimal')
+  price: number;
+
+  @ManyToOne(() => User)
+  architect: User;
+
+  @Column({ nullable: true })
+  fileUrl: string;
+}

--- a/backend/src/entities/BaseEntity.ts
+++ b/backend/src/entities/BaseEntity.ts
@@ -1,0 +1,12 @@
+import { PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+export abstract class BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/entities/Cart.ts
+++ b/backend/src/entities/Cart.ts
@@ -1,0 +1,24 @@
+import { Entity, Column, ManyToOne, OneToMany } from 'typeorm';
+import { BaseEntity } from './BaseEntity';
+import { User } from './User';
+import { CartItem } from './CartItem';
+
+export type CartStatus = 'active' | 'completed';
+
+@Entity()
+export class Cart extends BaseEntity {
+  @ManyToOne(() => User)
+  client: User;
+
+  @OneToMany(() => CartItem, (item) => item.cart)
+  items: CartItem[];
+
+  @Column('decimal')
+  total: number;
+
+  @Column('decimal')
+  approvedBudget: number;
+
+  @Column({ type: 'enum', enum: ['active', 'completed'], default: 'active' })
+  status: CartStatus;
+}

--- a/backend/src/entities/CartItem.ts
+++ b/backend/src/entities/CartItem.ts
@@ -1,0 +1,21 @@
+import { Entity, Column, ManyToOne } from 'typeorm';
+import { BaseEntity } from './BaseEntity';
+import { Cart } from './Cart';
+import { ArchitecturalPlan } from './ArchitecturalPlan';
+
+export type CartItemType = 'architectural' | 'terrain' | 'structural' | 'approval';
+
+@Entity()
+export class CartItem extends BaseEntity {
+  @ManyToOne(() => Cart, (cart) => cart.items)
+  cart: Cart;
+
+  @ManyToOne(() => ArchitecturalPlan)
+  plan: ArchitecturalPlan;
+
+  @Column({ type: 'enum', enum: ['architectural', 'terrain', 'structural', 'approval'] })
+  type: CartItemType;
+
+  @Column('decimal')
+  price: number;
+}

--- a/backend/src/entities/Lead.ts
+++ b/backend/src/entities/Lead.ts
@@ -1,0 +1,32 @@
+import { Entity, Column, ManyToOne } from 'typeorm';
+import { BaseEntity } from './BaseEntity';
+import { User } from './User';
+
+export type LeadStatus = 'pending' | 'approved' | 'rejected';
+
+@Entity()
+export class Lead extends BaseEntity {
+  @Column()
+  name: string;
+
+  @Column('decimal')
+  income: number;
+
+  @Column()
+  location: string;
+
+  @Column()
+  financingType: string;
+
+  @Column({ type: 'enum', enum: ['pending', 'approved', 'rejected'], default: 'pending' })
+  status: LeadStatus;
+
+  @ManyToOne(() => User)
+  client: User;
+
+  @ManyToOne(() => User)
+  banker: User;
+
+  @Column({ type: 'json', nullable: true })
+  documents: Record<string, string>;
+}

--- a/backend/src/entities/Notification.ts
+++ b/backend/src/entities/Notification.ts
@@ -1,0 +1,20 @@
+import { Entity, Column, ManyToOne } from 'typeorm';
+import { BaseEntity } from './BaseEntity';
+import { User } from './User';
+
+export type NotificationType = 'sale' | 'adaptation' | 'status_update';
+
+@Entity()
+export class Notification extends BaseEntity {
+  @ManyToOne(() => User)
+  recipient: User;
+
+  @Column()
+  message: string;
+
+  @Column({ type: 'enum', enum: ['sale', 'adaptation', 'status_update'] })
+  type: NotificationType;
+
+  @Column({ default: false })
+  read: boolean;
+}

--- a/backend/src/entities/Order.ts
+++ b/backend/src/entities/Order.ts
@@ -1,0 +1,28 @@
+import { Entity, Column, ManyToOne } from 'typeorm';
+import { BaseEntity } from './BaseEntity';
+import { User } from './User';
+import { Cart } from './Cart';
+
+export type OrderStatus = 'pending' | 'paid' | 'completed';
+export type PaymentMethod = 'pix' | 'boleto' | 'card';
+
+@Entity()
+export class Order extends BaseEntity {
+  @ManyToOne(() => User)
+  client: User;
+
+  @ManyToOne(() => Cart)
+  cart: Cart;
+
+  @Column({ type: 'enum', enum: ['pending', 'paid', 'completed'], default: 'pending' })
+  status: OrderStatus;
+
+  @Column({ nullable: true })
+  contractUrl: string;
+
+  @Column({ nullable: true })
+  invoiceUrl: string;
+
+  @Column({ type: 'enum', enum: ['pix', 'boleto', 'card'], nullable: true })
+  paymentMethod: PaymentMethod;
+}

--- a/backend/src/entities/User.ts
+++ b/backend/src/entities/User.ts
@@ -1,0 +1,22 @@
+import { Entity, Column } from 'typeorm';
+import { BaseEntity } from './BaseEntity';
+
+export type UserRole = 'client' | 'architect' | 'banker' | 'admin';
+
+@Entity()
+export class User extends BaseEntity {
+  @Column({ unique: true })
+  email: string;
+
+  @Column()
+  password: string;
+
+  @Column({ type: 'enum', enum: ['client', 'architect', 'banker', 'admin'] })
+  role: UserRole;
+
+  @Column({ nullable: true })
+  name: string;
+
+  @Column({ nullable: true })
+  creaCau: string;
+}

--- a/backend/src/entities/Wallet.ts
+++ b/backend/src/entities/Wallet.ts
@@ -1,0 +1,12 @@
+import { Entity, Column, ManyToOne } from 'typeorm';
+import { BaseEntity } from './BaseEntity';
+import { User } from './User';
+
+@Entity()
+export class Wallet extends BaseEntity {
+  @ManyToOne(() => User)
+  architect: User;
+
+  @Column('decimal', { default: 0 })
+  balance: number;
+}

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface AuthRequest extends Request {
+  user?: { id: string; role: string };
+}
+
+export function authenticate(req: AuthRequest, res: Response, next: NextFunction) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret') as { id: string; role: string };
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+}
+
+export function authorize(roles: string[]) {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    if (!req.user || !roles.includes(req.user.role)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    next();
+  };
+}

--- a/backend/src/repositories/GenericRepository.ts
+++ b/backend/src/repositories/GenericRepository.ts
@@ -1,0 +1,39 @@
+import { Repository, DeepPartial, getRepository } from 'typeorm';
+
+export class GenericRepository<T> {
+  private repo: Repository<T>;
+
+  constructor(entity: new () => T) {
+    this.repo = getRepository(entity);
+  }
+
+  async create(data: DeepPartial<T>): Promise<T> {
+    const entity = this.repo.create(data);
+    return this.repo.save(entity);
+  }
+
+  async findById(id: string): Promise<T | undefined> {
+    return this.repo.findOne(id);
+  }
+
+  async findAll(): Promise<T[]> {
+    return this.repo.find();
+  }
+
+  async update(id: string, data: DeepPartial<T>): Promise<T | undefined> {
+    await this.repo.update(id, data);
+    return this.findById(id);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.repo.delete(id);
+  }
+
+  async findBy(criteria: Partial<T>): Promise<T | undefined> {
+    return this.repo.findOne({ where: criteria });
+  }
+
+  async findAllBy(criteria: Partial<T>): Promise<T[]> {
+    return this.repo.find({ where: criteria });
+  }
+}

--- a/backend/src/routes/adaptationRoutes.ts
+++ b/backend/src/routes/adaptationRoutes.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import { GenericRepository } from '../repositories/GenericRepository';
+import { AdaptationRequest } from '../entities/AdaptationRequest';
+import { authenticate } from '../middleware/auth';
+
+const router = Router();
+const repo = new GenericRepository(AdaptationRequest);
+
+router.post('/', authenticate, async (req, res) => {
+  const request = await repo.create(req.body);
+  res.json(request);
+});
+
+router.put('/:id', authenticate, async (req, res) => {
+  const updated = await repo.update(req.params.id, req.body);
+  res.json(updated);
+});
+
+export default router;

--- a/backend/src/routes/cartRoutes.ts
+++ b/backend/src/routes/cartRoutes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { GenericRepository } from '../repositories/GenericRepository';
+import { Cart } from '../entities/Cart';
+import { authenticate } from '../middleware/auth';
+
+const router = Router();
+const repo = new GenericRepository(Cart);
+
+router.post('/', authenticate, async (req, res) => {
+  const { client } = req.body;
+  const existing = await repo.findBy({ client, status: 'active' } as any);
+  if (existing) {
+    const updated = await repo.update((existing as any).id, req.body);
+    return res.json(updated);
+  }
+  const cart = await repo.create(req.body);
+  res.json(cart);
+});
+
+router.get('/', authenticate, async (_req, res) => {
+  const carts = await repo.findAll();
+  res.json(carts);
+});
+
+export default router;

--- a/backend/src/routes/leadRoutes.ts
+++ b/backend/src/routes/leadRoutes.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import { GenericRepository } from '../repositories/GenericRepository';
+import { Lead } from '../entities/Lead';
+import { authenticate } from '../middleware/auth';
+
+const router = Router();
+const repo = new GenericRepository(Lead);
+
+router.post('/', authenticate, async (req, res) => {
+  const lead = await repo.create(req.body);
+  res.json(lead);
+});
+
+router.get('/', authenticate, async (_req, res) => {
+  const leads = await repo.findAll();
+  res.json(leads);
+});
+
+router.put('/:id', authenticate, async (req, res) => {
+  const updated = await repo.update(req.params.id, req.body);
+  res.json(updated);
+});
+
+export default router;

--- a/backend/src/routes/notificationRoutes.ts
+++ b/backend/src/routes/notificationRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { GenericRepository } from '../repositories/GenericRepository';
+import { Notification } from '../entities/Notification';
+import { authenticate } from '../middleware/auth';
+
+const router = Router();
+const repo = new GenericRepository(Notification);
+
+router.get('/', authenticate, async (req, res) => {
+  const notifications = await repo.findAllBy({ recipient: (req as any).user.id } as any);
+  res.json(notifications);
+});
+
+export default router;

--- a/backend/src/routes/orderRoutes.ts
+++ b/backend/src/routes/orderRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { GenericRepository } from '../repositories/GenericRepository';
+import { Order } from '../entities/Order';
+import { authenticate } from '../middleware/auth';
+
+const router = Router();
+const repo = new GenericRepository(Order);
+
+router.post('/', authenticate, async (req, res) => {
+  const order = await repo.create(req.body);
+  res.json(order);
+});
+
+export default router;

--- a/backend/src/routes/planRoutes.ts
+++ b/backend/src/routes/planRoutes.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import { GenericRepository } from '../repositories/GenericRepository';
+import { ArchitecturalPlan } from '../entities/ArchitecturalPlan';
+import { authenticate } from '../middleware/auth';
+
+const router = Router();
+const repo = new GenericRepository(ArchitecturalPlan);
+
+router.post('/', authenticate, async (req, res) => {
+  const plan = await repo.create(req.body);
+  res.json(plan);
+});
+
+router.get('/', authenticate, async (_req, res) => {
+  const plans = await repo.findAll();
+  res.json(plans);
+});
+
+export default router;

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express';
+import { GenericRepository } from '../repositories/GenericRepository';
+import { User } from '../entities/User';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { authenticate } from '../middleware/auth';
+
+const router = Router();
+const repo = new GenericRepository(User);
+
+router.post('/register', async (req, res) => {
+  const { email, password, role, name, creaCau } = req.body;
+  const hashed = await bcrypt.hash(password, 10);
+  const user = await repo.create({ email, password: hashed, role, name, creaCau });
+  res.json(user);
+});
+
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = await repo.findBy({ email });
+  if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+  const valid = await bcrypt.compare(password, (user as any).password);
+  if (!valid) return res.status(401).json({ message: 'Invalid credentials' });
+  const token = jwt.sign({ id: (user as any).id, role: (user as any).role }, process.env.JWT_SECRET || 'secret');
+  res.json({ token });
+});
+
+router.get('/me', authenticate, async (req, res) => {
+  const user = await repo.findById((req as any).user.id);
+  res.json(user);
+});
+
+export default router;

--- a/backend/src/routes/walletRoutes.ts
+++ b/backend/src/routes/walletRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { GenericRepository } from '../repositories/GenericRepository';
+import { Wallet } from '../entities/Wallet';
+import { authenticate } from '../middleware/auth';
+
+const router = Router();
+const repo = new GenericRepository(Wallet);
+
+router.get('/', authenticate, async (req, res) => {
+  const wallet = await repo.findBy({ architect: (req as any).user.id } as any);
+  res.json(wallet);
+});
+
+export default router;

--- a/backend/src/services/contractService.ts
+++ b/backend/src/services/contractService.ts
@@ -1,0 +1,3 @@
+export async function generateContract() {
+  // TODO: integrate with Docusign
+}

--- a/backend/src/services/invoiceService.ts
+++ b/backend/src/services/invoiceService.ts
@@ -1,0 +1,3 @@
+export async function issueInvoice() {
+  // TODO: integrate with NFE.io or Asaas
+}

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -1,0 +1,3 @@
+export async function sendNotification() {
+  // TODO: integrate with WhatsApp and panel
+}

--- a/backend/src/services/paymentService.ts
+++ b/backend/src/services/paymentService.ts
@@ -1,0 +1,3 @@
+export async function processPayment() {
+  // TODO: integrate with Asaas
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- stub out backend Express project with TypeScript
- add entities using TypeORM
- implement generic repository
- add middleware and basic routes
- configure TypeORM with sqlite and create main app
- provide minimal README

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6871a2b0aed48331a698c49e7937bec9